### PR TITLE
set default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ Pelican can nicely handle tags with whitespaces (for example `#My nice article`)
 
 This plugin depends on [Mastodon.py](https://github.com/halcy/Mastodon.py).
 
-In order to publish on Mastodon you need to enter in `publishconf.py` the following information:
+In order to publish on Mastodon you need to enter in `.env` file, on the site root directory, the following information:
 
 ``` python
-MASTODON_BASE_URL = 'URL of your Mastodon instance. For example https://mastodon.social'
-MASTODON_USERNAME = 'Your username for Mastodon login'
-MASTODON_PASSWORD = 'You password for Mastodon login'
+MASTODON_BASE_URL="URL of your Mastodon instance. For example https://mastodon.social"
+MASTODON_USERNAME="Your username for Mastodon login"
+MASTODON_PASSWORD="You password for Mastodon login"
 ```
+
 There is no need to register an app in your Mastodon profile because *Fediverse* will do it for you!
 
 On every run *Fediverse* looks for a file called `pelicanfediverse_clientcred.secret` and - if it is not found - it gets in touch with Mastodon, creates an app called *PelicanFediverse* and writes API keys and other necessary information in this file.

--- a/README.md
+++ b/README.md
@@ -51,3 +51,17 @@ There is no need to register an app in your Mastodon profile because *Fediverse*
 On every run *Fediverse* looks for a file called `pelicanfediverse_clientcred.secret` and - if it is not found - it gets in touch with Mastodon, creates an app called *PelicanFediverse* and writes API keys and other necessary information in this file.
 
 If you **cancel** this file *Fediverse* will create another app on its next run (this could be done in case of problem despite the fact Mastodon advise this is NOT a good behaviour since app should be created only once).
+
+
+## parameters
+
+In `pelicanconf.py` some new parameters can be defined
+
+ - **MASTODON_VISIBILITY** : Set post's visiblity on mastodon. Can be 'direct', 'private', 'unlisted' or 'public'. Default value = 'direct' 
+
+  More details : https://mastodonpy.readthedocs.io/en/stable/05_statuses.html#writing 
+ - **MASTODON_READ_MORE** : Text to add at the end of the post, before link to the pelican's article. Default value = 'Read more: '
+
+``` Python
+MASTODON_VISIBILITY='direct'
+MASTODON_READ_MORE='Read more: '

--- a/README.md
+++ b/README.md
@@ -51,3 +51,18 @@ There is no need to register an app in your Mastodon profile because *Fediverse*
 On every run *Fediverse* looks for a file called `pelicanfediverse_clientcred.secret` and - if it is not found - it gets in touch with Mastodon, creates an app called *PelicanFediverse* and writes API keys and other necessary information in this file.
 
 If you **cancel** this file *Fediverse* will create another app on its next run (this could be done in case of problem despite the fact Mastodon advise this is NOT a good behaviour since app should be created only once).
+
+## parameters
+
+In `pelicanconf.py` some new parameters can be defined
+
+ - **MASTODON_VISIBILITY** : Set post's visiblity on mastodon. Can be 'direct', 'private', 'unlisted' or 'public'. Default value = 'direct' 
+
+   More details : https://mastodonpy.readthedocs.io/en/stable/05_statuses.html#writing 
+
+ - **MASTODON_READ_MORE** : Text to add at the end of the post, before link to the pelican's article. Default value = 'Read more: '
+
+``` Python
+MASTODON_VISIBILITY='direct'
+MASTODON_READ_MORE='Read more: '
+``` 

--- a/fediverse.py
+++ b/fediverse.py
@@ -45,9 +45,9 @@ def post_on_mastodon(settings, new_posts):
    mt_password = os.getenv('MASTODON_PASSWORD')
 
    global mt_read_more
-   mt_read_more = settings.get('MASTODON_READ_MORE', '')
+   mt_read_more = settings.get('MASTODON_READ_MORE', 'Read more: ')
    global mt_visibility
-   mt_visibility = settings.get('MASTODON_VISIBILITY', '')
+   mt_visibility = settings.get('MASTODON_VISIBILITY', 'direct')
 
    # check if config file has been duly filled or print an error message and exit
    if mt_base_url == '' or mt_username == '' or mt_password == '':

--- a/fediverse.py
+++ b/fediverse.py
@@ -7,6 +7,7 @@ import sys
 import string
 from lxml import html
 import os.path
+from dotenv import load_dotenv
 
 import logging
 logger = logging.getLogger(__name__)
@@ -35,13 +36,18 @@ def write_articleslist(articleslist):
 # Collect config info and start the main procedure
 def post_on_mastodon(settings, new_posts):
 
+   load_dotenv()
    global mt_base_url
    mt_base_url = os.getenv('MASTODON_BASE_URL')
    global mt_username
    mt_username = os.getenv('MASTODON_USERNAME')
    global mt_password
-   mt_password = settings.get('MASTODON_PASSWORD', '')
    mt_password = os.getenv('MASTODON_PASSWORD')
+
+   global mt_read_more
+   mt_read_more = settings.get('MASTODON_READ_MORE', '')
+   global mt_visibility
+   mt_visibility = settings.get('MASTODON_VISIBILITY', '')
 
    # check if config file has been duly filled or print an error message and exit
    if mt_base_url == '' or mt_username == '' or mt_password == '':

--- a/fediverse.py
+++ b/fediverse.py
@@ -34,12 +34,14 @@ def write_articleslist(articleslist):
 
 # Collect config info and start the main procedure
 def post_on_mastodon(settings, new_posts):
+
    global mt_base_url
-   mt_base_url = settings.get('MASTODON_BASE_URL', '')
+   mt_base_url = os.getenv('MASTODON_BASE_URL')
    global mt_username
-   mt_username = settings.get('MASTODON_USERNAME', '')
+   mt_username = os.getenv('MASTODON_USERNAME')
    global mt_password
    mt_password = settings.get('MASTODON_PASSWORD', '')
+   mt_password = os.getenv('MASTODON_PASSWORD')
 
    # check if config file has been duly filled or print an error message and exit
    if mt_base_url == '' or mt_username == '' or mt_password == '':

--- a/fediverse.py
+++ b/fediverse.py
@@ -75,6 +75,7 @@ def post_on_mastodon(settings, new_posts):
 
    return True
 
+
 # Extract the list of new posts
 def post_updates(generator, writer):
    articleslist = read_articleslist()
@@ -110,7 +111,7 @@ def post_updates(generator, writer):
             articlehtmltext = article.summary
             articlecleantext = html.fromstring(articlehtmltext)
             summary_to_publish = articlecleantext.text_content().strip() + '\n'
-            read_more = 'Read more... ' + article.get_siteurl() + '/' + article.url + '\n\n'
+            read_more = mt_read_more + article.get_siteurl() + '/' + article.url + '\n\n'
             if hasattr(article, 'tags'):
                taglist = article.tags
                new_taglist = []
@@ -132,8 +133,11 @@ def post_updates(generator, writer):
                   mastodon_toot = title_to_publish + summary_to_publish + read_more
                else:
                   mastodon_toot = title_to_publish + summary_to_publish + read_more
-            mastodon.toot(mastodon_toot)
+
+            mastodon.status_post(mastodon_toot, visibility=mt_visibility)
+
          write_articleslist(articleslist)
+
 
 def register():
    try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Mastodon.py
-lxml
+lxml~=5.4.0
+python-dotenv~=1.1.0
+pelican~=4.11.0


### PR DESCRIPTION
In case parameters not defined in pelicanconf.py, set default values : 

- MASTODON_VISIBILITY = 'direct'
- MASTODON_READ_MORE = 'Read more: '

Update README.md